### PR TITLE
Add DevEx Rates

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -65,6 +65,7 @@ Tools to augument your game development experience
 - [ZonePlus](https://devforum.roblox.com/t/zoneplus-v2/1017701)
 - [Dynablox Opencloud](https://github.com/dynabloxjs/dynablox_opencloud)
 - [Rbx Gravity Controller](https://github.com/EgoMoose/Rbx-Gravity-Controller)
+- [DevEx Rates](https://github.com/supertj/devex-rates)
 
 
 ## Plugins


### PR DESCRIPTION
Adds [DevEx Rates](https://github.com/supertj/devex-rates) to Tools.

Roblox Developer Exchange rates as data: the three rates currently in force, every rate change on record since 2013, and the 30,000 Earned Robux minimum, plus a dependency-free Luau module for the arithmetic (Robux to USD at a given rate, mixed balances, the rate in force on a date). JSON is CC BY 4.0, code is MIT, and a CI check keeps the module in sync with the data.